### PR TITLE
feat(strapi): handle query params in `findOne` method

### DIFF
--- a/docs/pages/strapi.md
+++ b/docs/pages/strapi.md
@@ -24,7 +24,7 @@ this.$strapi.user.avatar = ''
 
 ## Methods
 
-### `find(entity, params)`
+### `find(entity, params?)`
 
 - Returns `Promise`
 
@@ -75,7 +75,7 @@ await $strapi.$products.find({ 'categories.name': ['women', 'men'], _limit: 200 
 
 > See the [Strapi endpoints](https://strapi.io/documentation/developer-docs/latest/developer-resources/content-api/content-api.html#endpoints).
 
-### `count(entity, params)`
+### `count(entity, params?)`
 
 - Returns `Promise`
 
@@ -89,7 +89,7 @@ await this.$strapi.$products.count(params)
 
 > See the [Strapi endpoints](https://strapi.io/documentation/developer-docs/latest/developer-resources/content-api/content-api.html#endpoints).
 
-### `findOne(entity, id)`
+### `findOne(entity, id, params?)`
 
 - Returns `Promise`
 
@@ -99,6 +99,12 @@ Get an entry. Returns an entry by id.
 await this.$strapi.findOne('products', 1)
 // With entity shortcut
 await this.$strapi.$products.findOne(1)
+```
+
+Like the `find` method, you can pass optional query params as a third argument:
+
+```js
+await this.$strapi.findOne('products', 1, { _publicationState: 'preview' })
 ```
 
 > See the [Strapi endpoints](https://strapi.io/documentation/developer-docs/latest/developer-resources/content-api/content-api.html#endpoints).
@@ -197,7 +203,7 @@ Performs an HTTP request to GraphQL API and returns its value
   import { getRestaurant } from 'restaurants.js'
 
   const restaurantId = 4;
-    
+
   await this.$strapi.graphql({
     query: getRestaurant(),
     variables: {

--- a/src/runtime/strapi.ts
+++ b/src/runtime/strapi.ts
@@ -137,8 +137,8 @@ export class Strapi extends Hookable {
     return this.$http.$get<T>(`/${entity}/count`, { searchParams })
   }
 
-  findOne<T = any, E = string> (entity: E, id: string): Promise<T> {
-    return this.$http.$get<T>(`/${entity}/${id}`)
+  findOne<T = any, E = string> (entity: E, id: string, searchParams?: NuxtStrapiQueryParams): Promise<T> {
+    return this.$http.$get<T>(`/${entity}/${id}`, { searchParams })
   }
 
   create<T = any, E = string> (entity: E, data: NuxtStrapiQueryParams): Promise<T> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
As mentioned by @jakubmirejovsky in https://github.com/nuxt-community/strapi-module/issues/148#issuecomment-875036022, the `findOne` method was missing the ability to pass query params.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
