### PR TITLE
feat: add `useStrapi` composable with correct types

### DIFF
--- a/docs/content/3.usage.md
+++ b/docs/content/3.usage.md
@@ -222,15 +222,38 @@ const user = await fetchUser()
 
 > Learn how to populate relations in [`/users/me` route](/setup#authpopulate).
 
-## `useStrapi{3|4}`
+## `useStrapi`
 
-Those composables are available for both `v3` and `v4` versions. Define version in your [options](/setup#options).
+Depending on which version you have in your [options](/setup#options), you will be using either the v3 or v4 client.
 
 ::alert{type="info"}
-All examples below are demonstrated with `useStrapi4()`. Note that `useStrapi3()` exposes the same methods. Check out specific types for [v3](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/v3.d.ts) and [v4](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/v4.d.ts).
+All examples below are demonstrated with v4 `useStrapi()`.
+
+Note that v3 exposes the same methods with different options. Check out specific types for [v3](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/v3.d.ts) and [v4](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/v4.d.ts).
 ::
 
 > Learn how to handle Strapi errors globally by using [nuxt hooks](/advanced#errors-handling).
+
+### Types
+
+When using the composable, you can pass in a default data model for all methods.
+
+```ts
+const { find } = useStrapi<Course>()
+
+// typed to Course
+findOne('courses', '123')
+```
+
+If you prefer not to use a default data type and want or want to overide the default, you can pass the data model on individual 
+methods as well.
+
+```ts
+const { find } = useStrapi<Course>()
+
+// typed to SpecialCourse
+findOne<SpecialCourse>('courses', '123')
+```
 
 ### `find`
 
@@ -244,11 +267,10 @@ Get entries. Returns entries matching the query filters (see [parameters](https:
 ```vue
 <script setup lang="ts">
 import type { Restaurant } from '~/types'
-import type { Strapi4ResponseMany } from '@nuxtjs/strapi'
 
-const { find } = useStrapi4()
+const { find } = useStrapi()
 
-const response = await find<Strapi4ResponseMany<Restaurant>>('restaurants')
+const response = await find<Restaurant>('restaurants')
 </script>
 ```
 
@@ -267,12 +289,11 @@ Returns an entry by `id`.
 ```vue
 <script setup lang="ts">
 import type { Restaurant } from '~/types'
-import type { Strapi4ResponseSingle } from '@nuxtjs/strapi'
 
 const route = useRoute()
-const { findOne } = useStrapi4()
+const { findOne } = useStrapi()
 
-const response = await findOne<Strapi4ResponseSingle<Restaurant>>('restaurants', route.params.id)
+const response = await findOne<Restaurant>('restaurants', route.params.id)
 </script>
 ```
 
@@ -290,12 +311,11 @@ Creates an entry and returns its value.
 ```vue
 <script setup lang="ts">
 import type { Restaurant } from '~/types'
-import type { Strapi4ResponseSingle } from '@nuxtjs/strapi'
 
-const { create } = useStrapi4()
+const { create } = useStrapi()
 
 const onSubmit = async () => {
-  await create<Strapi4ResponseSingle<Restaurant>>('restaurants', { name: 'My restaurant' })
+  await create<Restaurant>('restaurants', { name: 'My restaurant' })
 }
 </script>
 ```
@@ -315,13 +335,12 @@ Partially updates an entry by `id` and returns its value. Fields that aren't sen
 ```vue
 <script setup lang="ts">
 import type { Restaurant } from '~/types'
-import type { Strapi4ResponseSingle } from '@nuxtjs/strapi'
 
 const route = useRoute()
 const { update } = useStrapi4()
 
 const onSubmit = async () => {
-  await update<Strapi4ResponseSingle<Restaurant>>('restaurants', route.params.id, { name: 'My updated restaurant' })
+  await update<Restaurant>('restaurants', route.params.id, { name: 'My updated restaurant' })
 }
 </script>
 ```
@@ -340,14 +359,13 @@ Deletes an entry by id and returns its value.
 ```vue
 <script setup lang="ts">
 import type { Restaurant } from '~/types'
-import type { Strapi4ResponseSingle } from '@nuxtjs/strapi'
 
 const route = useRoute()
 // An alias is used here as `delete` is a reserved key-word.
 const { delete: _delete } = useStrapi4()
 
 const onSubmit = async () => {
-  await _delete<Strapi4ResponseSingle<Restaurant>>('restaurants', route.params.id)
+  await _delete<Restaurant>('restaurants', route.params.id)
 }
 </script>
 ```
@@ -369,7 +387,7 @@ Available only for `v3` as Strapi v4 can do the same thing with the [Pagination 
 
 ```vue
 <script setup lang="ts">
-const { count } = useStrapi3()
+const { count } = useStrapi()
 
 const total = await count('restaurants')
 </script>
@@ -416,7 +434,7 @@ const restaurant = await graphql(query, { id: route.params.id })
 
 ## `useStrapiClient`
 
-This composable is a wrapper around [Nuxt 3 `$fetch` helper](https://v3.nuxtjs.org/concepts/server-engine#direct-api-calls) that uses [`ohmyfetch`](https://github.com/unjs/ohmyfetch) under the hood. You can use this method to reach custom strapi endpoints not available in the `useStrapi{3|4}` composable.
+This composable is a wrapper around [Nuxt 3 `$fetch` helper](https://v3.nuxtjs.org/concepts/server-engine#direct-api-calls) that uses [`ohmyfetch`](https://github.com/unjs/ohmyfetch) under the hood. You can use this method to reach custom strapi endpoints not available in the `useStrapi` composable.
 
 - **Arguments:**
   - url: `string`

--- a/docs/content/3.usage.md
+++ b/docs/content/3.usage.md
@@ -244,11 +244,11 @@ Get entries. Returns entries matching the query filters (see [parameters](https:
 ```vue
 <script setup lang="ts">
 import type { Restaurant } from '~/types'
-import type { Strapi4Response } from '@nuxtjs/strapi'
+import type { Strapi4ResponseMany } from '@nuxtjs/strapi'
 
 const { find } = useStrapi4()
 
-const response = await find<Strapi4Response<Restaurant>>('restaurants')
+const response = await find<Strapi4ResponseMany<Restaurant>>('restaurants')
 </script>
 ```
 

--- a/docs/content/3.usage.md
+++ b/docs/content/3.usage.md
@@ -267,12 +267,12 @@ Returns an entry by `id`.
 ```vue
 <script setup lang="ts">
 import type { Restaurant } from '~/types'
-import type { Strapi4Response } from '@nuxtjs/strapi'
+import type { Strapi4ResponseSingle } from '@nuxtjs/strapi'
 
 const route = useRoute()
 const { findOne } = useStrapi4()
 
-const response = await findOne<Strapi4Response<Restaurant>>('restaurants', route.params.id)
+const response = await findOne<Strapi4ResponseSingle<Restaurant>>('restaurants', route.params.id)
 </script>
 ```
 
@@ -290,12 +290,12 @@ Creates an entry and returns its value.
 ```vue
 <script setup lang="ts">
 import type { Restaurant } from '~/types'
-import type { Strapi4Response } from '@nuxtjs/strapi'
+import type { Strapi4ResponseSingle } from '@nuxtjs/strapi'
 
 const { create } = useStrapi4()
 
 const onSubmit = async () => {
-  await create<Strapi4Response<Restaurant>>('restaurants', { name: 'My restaurant' })
+  await create<Strapi4ResponseSingle<Restaurant>>('restaurants', { name: 'My restaurant' })
 }
 </script>
 ```
@@ -315,13 +315,13 @@ Partially updates an entry by `id` and returns its value. Fields that aren't sen
 ```vue
 <script setup lang="ts">
 import type { Restaurant } from '~/types'
-import type { Strapi4Response } from '@nuxtjs/strapi'
+import type { Strapi4ResponseSingle } from '@nuxtjs/strapi'
 
 const route = useRoute()
 const { update } = useStrapi4()
 
 const onSubmit = async () => {
-  await update<Strapi4Response<Restaurant>>('restaurants', route.params.id, { name: 'My updated restaurant' })
+  await update<Strapi4ResponseSingle<Restaurant>>('restaurants', route.params.id, { name: 'My updated restaurant' })
 }
 </script>
 ```
@@ -340,14 +340,14 @@ Deletes an entry by id and returns its value.
 ```vue
 <script setup lang="ts">
 import type { Restaurant } from '~/types'
-import type { Strapi4Response } from '@nuxtjs/strapi'
+import type { Strapi4ResponseSingle } from '@nuxtjs/strapi'
 
 const route = useRoute()
 // An alias is used here as `delete` is a reserved key-word.
 const { delete: _delete } = useStrapi4()
 
 const onSubmit = async () => {
-  await _delete<Strapi4Response<Restaurant>>('restaurants', route.params.id)
+  await _delete<Strapi4ResponseSingle<Restaurant>>('restaurants', route.params.id)
 }
 </script>
 ```

--- a/docs/content/4.advanced.md
+++ b/docs/content/4.advanced.md
@@ -35,14 +35,13 @@ To take full advantage of server-side rendering, you can use Nuxt [useAsyncData]
 ```vue
 <script setup lang="ts">
 import type { Restaurant } from '~/types'
-import type { Strapi4ResponseSingle } from '@nuxtjs/strapi'
 
 const route = useRoute()
 const { findOne } = useStrapi4()
 
 const { data, pending, refresh, error } = await useAsyncData(
   'restaurant',
-  () => findOne<Strapi4ResponseSingle<Restaurant>>('restaurants', route.params.id)
+  () => findOne<Restaurant>('restaurants', route.params.id)
 )
 </script>
 ```

--- a/docs/content/4.advanced.md
+++ b/docs/content/4.advanced.md
@@ -35,14 +35,14 @@ To take full advantage of server-side rendering, you can use Nuxt [useAsyncData]
 ```vue
 <script setup lang="ts">
 import type { Restaurant } from '~/types'
-import type { Strapi4Response } from '@nuxtjs/strapi'
+import type { Strapi4ResponseSingle } from '@nuxtjs/strapi'
 
 const route = useRoute()
 const { findOne } = useStrapi4()
 
 const { data, pending, refresh, error } = await useAsyncData(
   'restaurant',
-  () => findOne<Strapi4Response<Restaurant>>('restaurants', route.params.id)
+  () => findOne<Strapi4ResponseSingle<Restaurant>>('restaurants', route.params.id)
 )
 </script>
 ```

--- a/src/module.ts
+++ b/src/module.ts
@@ -106,6 +106,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Add strapi composables
     nuxt.hook('autoImports:dirs', (dirs) => {
       dirs.push(resolve(runtimeDir, 'composables'))
+      dirs.push(resolve(runtimeDir, `composables-${options.version}`))
     })
 
     extendViteConfig((config) => {

--- a/src/runtime/composables-v3/useStrapi.ts
+++ b/src/runtime/composables-v3/useStrapi.ts
@@ -1,4 +1,5 @@
 import type { Strapi3RequestParams } from '../types/v3'
+// eslint-disable-next-line import/named
 import { useStrapi3 } from '#imports'
 
 interface StrapiV3Client<T> {

--- a/src/runtime/composables-v3/useStrapi.ts
+++ b/src/runtime/composables-v3/useStrapi.ts
@@ -1,0 +1,18 @@
+import type { Strapi3RequestParams } from '../types/v3'
+import { useStrapi3 } from '#imports'
+
+interface StrapiV3Client<T> {
+  count(contentType: string, params?: Strapi3RequestParams): Promise<number>
+  find<F = T[]>(contentType: string, params?: Strapi3RequestParams): Promise<F>
+  findOne<F = T>(contentType: string, id: string | number, params?: Strapi3RequestParams): Promise<F>
+  create<F = T>(contentType: string, data: Partial<F>): Promise<F>
+  update<F = T>(contentType: string, data: Partial<F>): Promise<F>
+  delete<F = T>(contentType: string, id: string | number | Partial<F>, data?: Partial<F>): Promise<F>
+}
+
+/**
+ * @deprecated use `useStrapi` for correct types
+ */
+export const useStrapi = <T>(): StrapiV3Client<T> => {
+  return useStrapi3()
+}

--- a/src/runtime/composables-v3/useStrapi.ts
+++ b/src/runtime/composables-v3/useStrapi.ts
@@ -10,9 +10,6 @@ interface StrapiV3Client<T> {
   delete<F = T>(contentType: string, id: string | number | Partial<F>, data?: Partial<F>): Promise<F>
 }
 
-/**
- * @deprecated use `useStrapi` for correct types
- */
 export const useStrapi = <T>(): StrapiV3Client<T> => {
   return useStrapi3()
 }

--- a/src/runtime/composables-v3/useStrapi3.ts
+++ b/src/runtime/composables-v3/useStrapi3.ts
@@ -1,6 +1,9 @@
 import type { Strapi3RequestParams } from '../types/v3'
 import { useStrapiVersion, useStrapiClient } from '#imports'
 
+/**
+ * @deprecated use `useStrapi` for correct types
+ */
 export const useStrapi3 = () => {
   const client = useStrapiClient()
   const version = useStrapiVersion()

--- a/src/runtime/composables-v3/useStrapi3.ts
+++ b/src/runtime/composables-v3/useStrapi3.ts
@@ -1,6 +1,5 @@
 import type { Strapi3RequestParams } from '../types/v3'
-import { useStrapiVersion } from './useStrapiVersion'
-import { useStrapiClient } from './useStrapiClient'
+import { useStrapiVersion, useStrapiClient } from '#imports'
 
 export const useStrapi3 = () => {
   const client = useStrapiClient()

--- a/src/runtime/composables-v4/useStrapi.ts
+++ b/src/runtime/composables-v4/useStrapi.ts
@@ -1,0 +1,14 @@
+import type { Strapi4ResponseSingle, Strapi4RequestParams, Strapi4ResponseMany } from '../types/v4'
+import { useStrapi4 } from '#imports'
+
+interface StrapiV4Client<T> {
+  find<F = T>(contentType: string, params?: Strapi4RequestParams): Promise<Strapi4ResponseMany<F>>
+  findOne<F = T>(contentType: string, id: string | number, params?: Strapi4RequestParams): Promise<Strapi4ResponseSingle<F>>
+  create<F = T>(contentType: string, data: Partial<F>): Promise<Strapi4ResponseSingle<F>>
+  update<F = T>(contentType: string, data: Partial<F>): Promise<Strapi4ResponseSingle<F>>
+  delete<F = T>(contentType: string, id: string | number | Partial<F>, data?: Partial<F>): Promise<Strapi4ResponseSingle<F>>
+}
+
+export const useStrapi = <T>(): StrapiV4Client<T> => {
+  return useStrapi4()
+}

--- a/src/runtime/composables-v4/useStrapi.ts
+++ b/src/runtime/composables-v4/useStrapi.ts
@@ -1,4 +1,5 @@
 import type { Strapi4ResponseSingle, Strapi4RequestParams, Strapi4ResponseMany } from '../types/v4'
+// eslint-disable-next-line import/named
 import { useStrapi4 } from '#imports'
 
 interface StrapiV4Client<T> {

--- a/src/runtime/composables-v4/useStrapi4.ts
+++ b/src/runtime/composables-v4/useStrapi4.ts
@@ -1,7 +1,9 @@
 import type { Strapi4RequestParams } from '../types/v4'
-import { useStrapiVersion } from './useStrapiVersion'
-import { useStrapiClient } from './useStrapiClient'
+import { useStrapiVersion, useStrapiClient } from '#imports'
 
+/**
+ * @deprecated use `useStrapi` for correct types
+ */
 export const useStrapi4 = () => {
   const client = useStrapiClient()
   const version = useStrapiVersion()

--- a/src/runtime/types/v4.d.ts
+++ b/src/runtime/types/v4.d.ts
@@ -51,9 +51,3 @@ export interface Strapi4ResponseMany<T> {
   data: Strapi4ResponseData<T>[],
   meta: Record<string, unknown>
 }
-
-
-export interface Strapi4ResponseMany<T> {
-  data: Strapi4ResponseData<T>[],
-  meta: Record<string, unknown>
-}

--- a/src/runtime/types/v4.d.ts
+++ b/src/runtime/types/v4.d.ts
@@ -46,3 +46,8 @@ export interface Strapi4ResponseSingle<T> {
   data: Strapi4ResponseData<T>,
   meta: Record<string, unknown>
 }
+
+export interface Strapi4ResponseMany<T> {
+  data: Strapi4ResponseData<T>[],
+  meta: Record<string, unknown>
+}

--- a/src/runtime/types/v4.d.ts
+++ b/src/runtime/types/v4.d.ts
@@ -41,3 +41,8 @@ export interface Strapi4Response<T> {
   data: Strapi4ResponseData<T> | Strapi4ResponseData<T>[],
   meta: Record<string, unknown>
 }
+
+export interface Strapi4ResponseSingle<T> {
+  data: Strapi4ResponseData<T>,
+  meta: Record<string, unknown>
+}

--- a/src/runtime/types/v4.d.ts
+++ b/src/runtime/types/v4.d.ts
@@ -51,3 +51,9 @@ export interface Strapi4ResponseMany<T> {
   data: Strapi4ResponseData<T>[],
   meta: Record<string, unknown>
 }
+
+
+export interface Strapi4ResponseMany<T> {
+  data: Strapi4ResponseData<T>[],
+  meta: Record<string, unknown>
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR aims to fix broken types without introducing breaking changes.

See: 
- https://github.com/nuxt-modules/strapi/issues/268
- https://github.com/nuxt-modules/strapi/issues/274

To summarise the type issues:
- single/multiple return requests have ambiguous types
- it's not possible to type the update / create functions without an error

To fix the types without breaking anything, I've introduced a new composable `useStrapi` which is a simple wrapper to the existing v3 or v4 client, depending on which version is being used, with the correct types.

The types for the client allow a user to either set a default type for all requests from the composable `useStrapi<MyData>` and / or override the single data return types from the functions `find<Book>('book')`

`useStrapi3` and `useStrapi4` are deprecated in favour of this to notify users they should swap over, this can be removed but I think it's worth while to have a single composable in the docs which have correct types

I believe these changes are a huge DX improvement:
- No type importing
- Single and multiple return types are automatically handled 
- Proper types for CRUD
- Single composable, makes upgrading easier

While this shouldn't break anything, it should be a minor bump and simple migration docs should be included in the release


## :warning: Note

While these changes have minimal scope for breaking things there are no test cases and I've never used strapi, so ideally someone would test this PR locally before merging.


## Migration

Check the [docs](https://strapi.nuxtjs.org/usage) for latest type guidelines.

**Previous version**

```ts
import type { Strapi4Response } from '@nuxtjs/strapi'
const { find } = useStrapi4()
const response = await find<Strapi4Response<Restaurant>>('restaurants')
```

**New version**

```ts
const { find } = useStrapi()
const response = await find<Restaurant>('restaurants')
```

or

```ts
const { find } = useStrapi<Restaurant>()
const response = await find('restaurants')
```



## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why) - **no test suit**
