### PR TITLE
docs: add populate nested field docs

### DIFF
--- a/docs/content/3.usage.md
+++ b/docs/content/3.usage.md
@@ -252,6 +252,16 @@ const response = await find<Strapi4Response<Restaurant>>('restaurants')
 </script>
 ```
 
+#### Populate nested fields using dot notation
+
+```vue
+<script setup lang="ts">
+const response = await find<Strapi4Response<Restaurant>>(
+  ['restaurants', 'restaurants.mediaField', 'restaurants.someComponent']
+)
+</script>
+```
+
 > Check out the Strapi [Get entries](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html#get-entries) REST API endpoint.
 
 ### `findOne`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This PR adds a little snippet under the `find()` docs describing how to populate nested fields which isn't readily apparent. It took me (and at least one other person) many hours of searching around and exhausting every option before finally sorting this out.
 I'm not sure if this is the best place for it, but I feel based on the lack of documentation elsewhere on using the dot notation here, it should be added somewhere at least.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
