### PR TITLE
feat(composables): add `useStrapiMedia`

### DIFF
--- a/docs/content/3.usage.md
+++ b/docs/content/3.usage.md
@@ -481,3 +481,13 @@ This composable is an helper to get version defined in options. It is used inter
 const version = useStrapiVersion()
 </script>
 ```
+
+## `useStrapiMedia`
+
+This composable is an helper to get full url for media. By default, Strapi endpoints return an media URL in the form `/uploads/image-[hash].png`.
+
+```vue
+<script setup>
+const media = useStrapiMedia()
+</script>
+```

--- a/src/runtime/composables/useStrapiMedia.ts
+++ b/src/runtime/composables/useStrapiMedia.ts
@@ -1,0 +1,7 @@
+import { useRuntimeConfig } from '#app'
+
+export const useStrapiMedia = (url: string): string => {
+  const config = useRuntimeConfig()
+
+  return config.strapi.url + url
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
By default, for local provider Strapi endpoints return an media URL in the form `/uploads/image-[hash].png`. 

This is bit problematic and require assign two variables or custom composable to get full url to `<img` tag.

So I add to the repository appropriate composable that can be used in the application code without additional manipulation of strings.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
