### PR TITLE
fix(composables): handle single types

### DIFF
--- a/docs/content/3.usage.md
+++ b/docs/content/3.usage.md
@@ -4,7 +4,6 @@ Learn how to use the strapi module in your Nuxt 3 application.
 
 > This module exposes composables that are [auto-imported](https://nuxt.com/docs/guide/directory-structure/composables) by Nuxt 3.
 
-
 ## `useStrapi`
 
 Depending on which version you have in your [options](/setup#options), you will be using either the v3 or v4 client.
@@ -16,7 +15,6 @@ Note that v3 exposes the same methods with different options. Check out specific
 ::
 
 > Learn how to handle Strapi errors globally by using [nuxt hooks](/advanced#errors-handling).
-
 
 ::alert{type="warning"}
 All examples below are demonstrated with http calls in script setup. However, to handle SSR properly you may want to use [useAsyncData](/advanced#async-data).
@@ -33,8 +31,7 @@ const { find } = useStrapi<Course>()
 findOne('courses', '123')
 ```
 
-If you prefer not to use a default data type and want or want to overide the default, you can pass the data model on individual 
-methods as well.
+If you prefer not to use a default data type and want to override the default, you can pass the data model on individual methods as well.
 
 ```ts
 const { find } = useStrapi<Course>()
@@ -70,7 +67,7 @@ Returns an entry by `id`.
 
 - **Arguments:**
   - contentType: `string`
-  - id: `string | number`
+  - id?: `string | number | Strapi4RequestParams`
   - params?: [`Strapi4RequestParams`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/v4.d.ts#L24)
 - **Returns:** `Promise<T>`
 
@@ -84,6 +81,10 @@ const { findOne } = useStrapi()
 const response = await findOne<Restaurant>('restaurants', route.params.id)
 </script>
 ```
+
+::alert{type="info"}
+This method can be used to get a single type entry as `id` is optional.
+::
 
 > Check out the Strapi [Get an entry](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html#get-an-entry) REST API endpoint.
 
@@ -116,7 +117,7 @@ Partially updates an entry by `id` and returns its value. Fields that aren't sen
 
 - **Arguments:**
   - contentType: `string`
-  - id: `string | number | Partial<T>`
+  - id?: `string | number | Partial<T>`
   - data?: `Partial<T>`
 - **Returns:** `Promise<T>`
 
@@ -132,6 +133,10 @@ const onSubmit = async () => {
 }
 </script>
 ```
+
+::alert{type="info"}
+This method can be used to update/create a single type entry as `id` is optional.
+::
 
 > Check out the Strapi [Update an entry](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html#update-an-entry) REST API endpoint.
 
@@ -157,6 +162,10 @@ const onSubmit = async () => {
 }
 </script>
 ```
+
+::alert{type="info"}
+This method can be used to delete a single type entry as `id` is optional.
+::
 
 > Check out the Strapi [Delete an entry](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html#delete-an-entry) REST API endpoint.
 

--- a/src/runtime/composables-v3/useStrapi.ts
+++ b/src/runtime/composables-v3/useStrapi.ts
@@ -5,9 +5,9 @@ import { useStrapi3 } from '#imports'
 interface StrapiV3Client<T> {
   count(contentType: string, params?: Strapi3RequestParams): Promise<number>
   find<F = T[]>(contentType: string, params?: Strapi3RequestParams): Promise<F>
-  findOne<F = T>(contentType: string, id: string | number, params?: Strapi3RequestParams): Promise<F>
+  findOne<F = T>(contentType: string, id?: string | number | Strapi3RequestParams, params?: Strapi3RequestParams): Promise<F>
   create<F = T>(contentType: string, data: Partial<F>): Promise<F>
-  update<F = T>(contentType: string, id: string | number | Partial<F>, data?: Partial<F>): Promise<F>
+  update<F = T>(contentType: string, id?: string | number | Partial<F>, data?: Partial<F>): Promise<F>
   delete<F = T>(contentType: string, id?: string | number): Promise<F>
 }
 

--- a/src/runtime/composables-v3/useStrapi3.ts
+++ b/src/runtime/composables-v3/useStrapi3.ts
@@ -42,8 +42,16 @@ export const useStrapi3 = () => {
    * @param  {Strapi3RequestParams} params? - Query parameters
    * @returns Promise<T>
    */
-  const findOne = <T>(contentType: string, id: string | number, params?: Strapi3RequestParams): Promise<T> => {
-    return client(`/${contentType}/${id}`, { method: 'GET', params })
+  const findOne = <T>(contentType: string, id?: string | number | Strapi3RequestParams, params?: Strapi3RequestParams): Promise<T> => {
+    if (typeof id === 'object') {
+      params = id
+      // @ts-ignore
+      id = undefined
+    }
+
+    const path = [contentType, id].filter(Boolean).join('/')
+
+    return client(path, { method: 'GET', params })
   }
 
   /**
@@ -65,9 +73,10 @@ export const useStrapi3 = () => {
    * @param  {Record<string, any>} data - Form data
    * @returns Promise<T>
    */
-  const update = <T>(contentType: string, id: string | number | Partial<T>, data?: Partial<T>): Promise<T> => {
+  const update = <T>(contentType: string, id?: string | number | Partial<T>, data?: Partial<T>): Promise<T> => {
     if (typeof id === 'object') {
       data = id
+      // @ts-ignore
       id = undefined
     }
 

--- a/src/runtime/composables-v4/useStrapi.ts
+++ b/src/runtime/composables-v4/useStrapi.ts
@@ -4,9 +4,9 @@ import { useStrapi4 } from '#imports'
 
 interface StrapiV4Client<T> {
   find<F = T>(contentType: string, params?: Strapi4RequestParams): Promise<Strapi4ResponseMany<F>>
-  findOne<F = T>(contentType: string, id: string | number, params?: Strapi4RequestParams): Promise<Strapi4ResponseSingle<F>>
+  findOne<F = T>(contentType: string, id?: string | number | Strapi4RequestParams, params?: Strapi4RequestParams): Promise<Strapi4ResponseSingle<F>>
   create<F = T>(contentType: string, data: Partial<F>): Promise<Strapi4ResponseSingle<F>>
-  update<F = T>(contentType: string, id: string | number | Partial<F>, data?: Partial<F>): Promise<Strapi4ResponseSingle<F>>
+  update<F = T>(contentType: string, id?: string | number | Partial<F>, data?: Partial<F>): Promise<Strapi4ResponseSingle<F>>
   delete<F = T>(contentType: string, id?: string | number): Promise<Strapi4ResponseSingle<F>>
 }
 

--- a/src/runtime/composables-v4/useStrapi4.ts
+++ b/src/runtime/composables-v4/useStrapi4.ts
@@ -31,8 +31,16 @@ export const useStrapi4 = () => {
    * @param  {Strapi4RequestParams} params? - Query parameters
    * @returns Promise<T>
    */
-  const findOne = <T>(contentType: string, id: string | number, params?: Strapi4RequestParams): Promise<T> => {
-    return client(`/${contentType}/${id}`, { method: 'GET', params })
+  const findOne = <T>(contentType: string, id?: string | number | Strapi4RequestParams, params?: Strapi4RequestParams): Promise<T> => {
+    if (typeof id === 'object') {
+      params = id
+      // @ts-ignore
+      id = undefined
+    }
+
+    const path = [contentType, id].filter(Boolean).join('/')
+
+    return client(path, { method: 'GET', params })
   }
 
   /**
@@ -54,7 +62,7 @@ export const useStrapi4 = () => {
    * @param  {Record<string, any>} data - Form data
    * @returns Promise<T>
    */
-  const update = <T>(contentType: string, id: string | number | Partial<T>, data?: Partial<T>): Promise<T> => {
+  const update = <T>(contentType: string, id?: string | number | Partial<T>, data?: Partial<T>): Promise<T> => {
     if (typeof id === 'object') {
       data = id
       // @ts-ignore


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Support single types on `findOne`, `update` and `delete` methods for strapi v3 and v4 by making the `id` parameter optional.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Resolves nuxt-modules/strapi#287

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
