### PR TITLE
docs: deprecated usage of `useStrapi4` + missing old tailwind classes

### DIFF
--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -1,0 +1,15 @@
+.inline-flex {
+  display: inline-flex;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.gap-3 {
+  gap: 0.75rem;
+}
+
+.strapi-title {
+  color: #4945ff;
+}

--- a/docs/content/3.usage.md
+++ b/docs/content/3.usage.md
@@ -126,7 +126,7 @@ Partially updates an entry by `id` and returns its value. Fields that aren't sen
 import type { Restaurant } from '~/types'
 
 const route = useRoute()
-const { update } = useStrapi4()
+const { update } = useStrapi()
 
 const onSubmit = async () => {
   await update<Restaurant>('restaurants', route.params.id, { name: 'My updated restaurant' })
@@ -155,7 +155,7 @@ import type { Restaurant } from '~/types'
 
 const route = useRoute()
 // An alias is used here as `delete` is a reserved key-word.
-const { delete: _delete } = useStrapi4()
+const { delete: _delete } = useStrapi()
 
 const onSubmit = async () => {
   await _delete<Restaurant>('restaurants', route.params.id)

--- a/docs/content/5.advanced.md
+++ b/docs/content/5.advanced.md
@@ -11,7 +11,7 @@ To take full advantage of server-side rendering, you can use Nuxt [useAsyncData]
 import type { Restaurant } from '~/types'
 
 const route = useRoute()
-const { findOne } = useStrapi4()
+const { findOne } = useStrapi()
 
 const { data, pending, refresh, error } = await useAsyncData(
   'restaurant',

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -1,4 +1,5 @@
 export default defineNuxtConfig({
+  css: ['@/assets/css/main.css'],
   extends: ['@nuxt-themes/docus'],
   modules: ['nuxt-plausible'],
   plausible: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Couple small changes:

1. Updated the docs to change use of the deprecated `useStrapi4` composable to `useStrapi`.

2. It seems that tailwind was removed from docus at some point, but was still being used to style the `badge` container(s). It was also used to style `Strapi` in the hero title. I'm not sure if that's still wanted and you might want to change the `.strapi-title` class name or remove that coloring all together. I at least just wanted to bring these style issues to light.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
