### PR TITLE
chore: change default api url value

### DIFF
--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -33,7 +33,7 @@ Defaults:
 
 ```ts
 {
-  url: process.env.STRAPI_URL || 'http://localhost:1337',
+  url: process.env.STRAPI_URL || 'http://127.0.0.1:1337',
   prefix: '/api',
   version: 'v4',
   cookie: {},
@@ -47,7 +47,7 @@ If you want to override any options on runtime, you may use [Nuxt 3 runtime-conf
 runtimeConfig: {
    public: {
       strapi: {
-        url: 'http://localhost:1337' // can be overridden by NUXT_PUBLIC_STRAPI_URL environment variable
+        url: 'http://127.0.0.1:1337' // can be overridden by NUXT_PUBLIC_STRAPI_URL environment variable
       }
    }
 },

--- a/example/nuxt.config.ts
+++ b/example/nuxt.config.ts
@@ -6,14 +6,14 @@ export default defineNuxtConfig({
   ],
   // example of separate client/server URLs
   // runtimeConfig: {
-  //   strapi: { url: 'http://localhost:1337' },
+  //   strapi: { url: 'http://127.0.0.1:1337' },
   //   public: {
-  //     strapi: { url: 'http://localhost:1337' }
+  //     strapi: { url: 'http://127.0.0.1:1337' }
   //   }
   // },
   strapi: {
     version: 'v3',
-    url: 'http://localhost:1337'
+    url: 'http://127.0.0.1:1337'
     // To enable the devtools, read https://strapi.nuxtjs.org/devtools
     // devtools: true
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -82,7 +82,7 @@ export default defineNuxtModule<ModuleOptions>({
     cookieName: 'strapi_jwt',
     devtools: false
   },
-  setup(options, nuxt) {
+  setup (options, nuxt) {
     // Default runtimeConfig
     nuxt.options.runtimeConfig.public.strapi = defu(nuxt.options.runtimeConfig.public.strapi, options)
     nuxt.options.runtimeConfig.strapi = defu(nuxt.options.runtimeConfig.strapi, options)

--- a/src/module.ts
+++ b/src/module.ts
@@ -12,7 +12,7 @@ export interface ModuleOptions {
   /**
    * Strapi API URL
    * @default process.env.STRAPI_URL
-   * @example 'http://localhost:1337'
+   * @example 'http://127.0.0.1:1337'
    * @type string
    */
   url?: string
@@ -74,7 +74,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
   },
   defaults: {
-    url: process.env.STRAPI_URL || 'http://localhost:1337',
+    url: process.env.STRAPI_URL || 'http://127.0.0.1:1337',
     prefix: '/api',
     version: 'v4',
     cookie: {},
@@ -82,7 +82,7 @@ export default defineNuxtModule<ModuleOptions>({
     cookieName: 'strapi_jwt',
     devtools: false
   },
-  setup (options, nuxt) {
+  setup(options, nuxt) {
     // Default runtimeConfig
     nuxt.options.runtimeConfig.public.strapi = defu(nuxt.options.runtimeConfig.public.strapi, options)
     nuxt.options.runtimeConfig.strapi = defu(nuxt.options.runtimeConfig.strapi, options)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
When using any node version above 16, the cookie was not being persisted across browser refreshes. Changing "http://localhost:1337" -> "http://127.0.0.1:1337" fixed this issue. Refer to this issue: https://github.com/nuxt-modules/strapi/issues/229

Resolves: #229 


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
