### PR TITLE
Resolve "dns" Module Externalization Warning in useStrapiClient.mjs

### DIFF
--- a/src/runtime/composables/useStrapiClient.ts
+++ b/src/runtime/composables/useStrapiClient.ts
@@ -1,6 +1,5 @@
 import type { FetchError, FetchOptions } from 'ofetch'
 import { stringify } from 'qs'
-import dns from 'dns'
 import type { Strapi4Error } from '../types/v4'
 import type { Strapi3Error } from '../types/v3'
 import { useStrapiUrl } from './useStrapiUrl'
@@ -9,8 +8,11 @@ import { useStrapiToken } from './useStrapiToken'
 import { useNuxtApp } from '#imports'
 
 // Fixes `ECONNREFUSED` on Node 18: https://github.com/node-fetch/node-fetch/issues/1624#issuecomment-1407717012
+// Import dns only if running in a server environment during development
 if (process.server && process.dev) {
-  dns.setDefaultResultOrder('ipv4first')
+  import('dns')
+    .then((dns) => dns.setDefaultResultOrder('ipv4first'))
+    .catch((error) => console.error('Error importing dns module:', error));
 }
 
 const defaultErrors = (err: FetchError) => ({


### PR DESCRIPTION
This pull request addresses the warning related to the "dns" module externalization for browser compatibility in the useStrapiClient.mjs file. The warning appeared during the Vite resolve process, and this change ensures that the "dns" module is imported conditionally only in a server environment during development. This modification aligns with best practices for handling browser-incompatible modules and resolves the warning mentioned in the Vite troubleshooting guide.

Please review and merge at your earliest convenience. If there are any specific guidelines or adjustments needed, feel free to provide feedback. Thank you!

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
