### PR TITLE
Eliminate Deprecated DNS Module Import

### DIFF
--- a/src/runtime/composables/useStrapiClient.ts
+++ b/src/runtime/composables/useStrapiClient.ts
@@ -7,13 +7,7 @@ import { useStrapiVersion } from './useStrapiVersion'
 import { useStrapiToken } from './useStrapiToken'
 import { useNuxtApp } from '#imports'
 
-// Fixes `ECONNREFUSED` on Node 18: https://github.com/node-fetch/node-fetch/issues/1624#issuecomment-1407717012
-// Import dns only if running in a server environment during development
-if (process.server && process.dev) {
-  import('dns')
-    .then((dns) => dns.setDefaultResultOrder('ipv4first'))
-    .catch((error) => console.error('Error importing dns module:', error))
-}
+
 
 const defaultErrors = (err: FetchError) => ({
   v4: {


### PR DESCRIPTION
This PR addresses a deprecated DNS module import, following Vite's documentation guidance. Vite discourages the use of Node.js modules in the browser due to potential bundle size increase. The import block has been removed, aligning the codebase with recommended practices for more efficient and browser-compatible builds. The adjustment reflects Vite's emphasis on minimizing the inclusion of Node.js-specific modules in client-side code. 

I would like to extend my sincere apologies for any inconvenience caused by the recent pull request [https://github.com/nuxt-modules/strapi/pull/370](url).
After careful reconsideration, I've recognized an error in my assessment, and the changes made in the previous pull request were not aligned with the best interests of the project. This new pull request aims to definitely remove the DNS module import, ensuring that the application's functionality is maintained as intended. I appreciate your understanding, and I apologize for any confusion caused.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Vite recommend avoiding Node.js modules for browser code to reduce the bundle size
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
