### PR TITLE
docs(auth): advise a minimal cookie config

### DIFF
--- a/docs/content/4.auth.md
+++ b/docs/content/4.auth.md
@@ -7,24 +7,21 @@ description: Learn how to authenticate users with the strapi module in your Nuxt
 
 ## Configuration
 
-When using @nuxtjs/strapi for authentication, the user jwt_token will be stored in a cookie. By using the default cookie configuration, the expiration will be set to "Session", which means the cookie will disappear when the browser is closed, and users will have to log in everytime.
+When using `@nuxtjs/strapi` for authentication, the user jwt token will be stored in a cookie (`strapi_jwt` by default). By using the default cookie configuration, the expiration will be set to `Session`, which means the cookie will disappear when the browser is closed, and users will have to log in everytime.
 
-If you want your cookie to stay for longer, we recommand you use the configuration below (expiration is set to 14 days, feel free to change) :
+If you want your cookie to stay longer, we recommand to use the configuration below (expiration is set to 14 days, feel free to change it):
 
-```ts
-// nuxt.config.ts
-
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
-  //...
   strapi: {
-        cookie: {
-          maxAge: 14 * 24 * 60 * 60,
-          secure: process.env.NODE_ENV === 'production',
-          sameSite: true
-        }
+    cookie: {
+      path: '/',
+      maxAge: 14 * 24 * 60 * 60,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: true
+    }
   }
-  //...
-});
+})
 ```
 
 ## `useStrapiUser`
@@ -36,7 +33,6 @@ const user = useStrapiUser()
 ```
 
 > Learn how to protect your routes by writing your own [auth middleware composable](/advanced#auth-middleware).
-
 
 ## `useStrapiToken`
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Description

By using the default cookie configuration {} and not setting a maxAge, the cookie becomes a SessionCookie by default, which is not what most people want when deploying a website! I just added some minimal configuration in the authentication docs. 


## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
