### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/src/runtime/composables/useStrapiAuth.ts
+++ b/src/runtime/composables/useStrapiAuth.ts
@@ -23,7 +23,7 @@ export const useStrapiAuth = () => {
   const token = useStrapiToken()
   const user = useStrapiUser()
   const client = useStrapiClient()
-  const config = process.server ? useRuntimeConfig() : useRuntimeConfig().public
+  const config = import.meta.server ? useRuntimeConfig() : useRuntimeConfig().public
 
   const setToken = (value: string | null) => {
     token.value = value

--- a/src/runtime/composables/useStrapiGraphQL.ts
+++ b/src/runtime/composables/useStrapiGraphQL.ts
@@ -6,7 +6,7 @@ import { useRuntimeConfig } from '#imports'
 
 export const useStrapiGraphQL = () => {
   const client = useStrapiClient()
-  const config = process.server ? useRuntimeConfig() : useRuntimeConfig().public
+  const config = import.meta.server ? useRuntimeConfig() : useRuntimeConfig().public
 
   return <T> (query: string|DocumentNode, variables?: StrapiGraphqlVariables): Promise<T> => {
     const queryAsString = typeof query === 'string' ? query : print(query)

--- a/src/runtime/composables/useStrapiMedia.ts
+++ b/src/runtime/composables/useStrapiMedia.ts
@@ -2,7 +2,7 @@ import { joinURL } from 'ufo'
 import { useRuntimeConfig } from '#imports'
 
 export const useStrapiMedia = (path: string): string => {
-  const config = process.server ? useRuntimeConfig() : useRuntimeConfig().public
+  const config = import.meta.server ? useRuntimeConfig() : useRuntimeConfig().public
 
   return joinURL(config.strapi.url, path)
 }

--- a/src/runtime/composables/useStrapiToken.ts
+++ b/src/runtime/composables/useStrapiToken.ts
@@ -3,7 +3,7 @@ import { useCookie, useNuxtApp, useRuntimeConfig } from '#imports'
 
 export const useStrapiToken = () => {
   const nuxt = useNuxtApp()
-  const config = process.server ? useRuntimeConfig() : useRuntimeConfig().public
+  const config = import.meta.server ? useRuntimeConfig() : useRuntimeConfig().public
 
   nuxt._cookies = nuxt._cookies || {}
   if (nuxt._cookies[config.strapi.cookieName]) {

--- a/src/runtime/composables/useStrapiUrl.ts
+++ b/src/runtime/composables/useStrapiUrl.ts
@@ -1,7 +1,7 @@
 import { useRuntimeConfig } from '#imports'
 
 export const useStrapiUrl = (): string => {
-  const config = process.server ? useRuntimeConfig() : useRuntimeConfig().public
+  const config = import.meta.server ? useRuntimeConfig() : useRuntimeConfig().public
 
   const version = config.strapi.version
   return version === 'v3' ? config.strapi.url : `${config.strapi.url}${config.strapi.prefix}`

--- a/src/runtime/composables/useStrapiVersion.ts
+++ b/src/runtime/composables/useStrapiVersion.ts
@@ -1,7 +1,7 @@
 import { useRuntimeConfig } from '#imports'
 
 export const useStrapiVersion = (): string => {
-  const config = process.server ? useRuntimeConfig() : useRuntimeConfig().public
+  const config = import.meta.server ? useRuntimeConfig() : useRuntimeConfig().public
 
   return config.strapi.version
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
