### PR TITLE
fix(module): export runtime types

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -3,6 +3,8 @@ import { defineNuxtModule, addImportsDir, addPlugin, createResolver, extendViteC
 import type { CookieOptions } from 'nuxt/app'
 import { joinURL } from 'ufo'
 
+export type * from './runtime/types'
+
 export interface AuthOptions {
   populate?: string | string[]
   fields?: string | string[]


### PR DESCRIPTION
Fixes #379
allows to do:

```typescript
import type { Strapi4RequestParams } from "@nuxtjs/strapi";

const useProducts = (filters: StrapiRequestParams['filters']) => useStrapi(...)
```

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
