### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -6,22 +6,9 @@ description: Learn how to setup strapi module in your Nuxt 3 application.
 ## Installation
 
 Add `@nuxtjs/strapi` dev dependency to your project:
-
-::code-group
-
-```bash [pnpm]
-pnpm add @nuxtjs/strapi
+```bash
+npx nuxi@latest module add strapi
 ```
-
-```bash [yarn]
-yarn add @nuxtjs/strapi
-```
-
-```bash [npm]
-npm install @nuxtjs/strapi
-```
-
-::
 
 Then, add `@nuxtjs/strapi` to the [`modules`](https://nuxt.com/docs/api/configuration/nuxt-config#modules) section of your Nuxt configuration:
 

--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -5,7 +5,8 @@ description: Learn how to setup strapi module in your Nuxt 3 application.
 
 ## Installation
 
-Add `@nuxtjs/strapi` dev dependency to your project:
+1. Add `@nuxtjs/strapi` module to your project:
+
 ```bash
 npx nuxi@latest module add strapi
 ```

--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -11,7 +11,7 @@ description: Learn how to setup strapi module in your Nuxt 3 application.
 npx nuxi@latest module add strapi
 ```
 
-Then, add `@nuxtjs/strapi` to the [`modules`](https://nuxt.com/docs/api/configuration/nuxt-config#modules) section of your Nuxt configuration:
+2. Add it to the `modules` section in your `nuxt.config.ts`:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏



## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
