### PR TITLE
chore(useStrapi): add optional query params to `create` / `update` in `v5`

### DIFF
--- a/src/runtime/composables-v5/useStrapi.ts
+++ b/src/runtime/composables-v5/useStrapi.ts
@@ -73,7 +73,7 @@ export const useStrapi = <T>(): StrapiV5Client<T> => {
 
     const path = [contentType, documentId].filter(Boolean).join('/')
 
-    return client(path, { method: 'PUT', body: { data } })
+    return client(path, { method: 'PUT', body: { data }, params })
   }
 
   /**

--- a/src/runtime/composables-v5/useStrapi.ts
+++ b/src/runtime/composables-v5/useStrapi.ts
@@ -49,10 +49,11 @@ export const useStrapi = <T>(): StrapiV5Client<T> => {
    *
    * @param  {string} contentType - Content type's name pluralized
    * @param  {Record<string, any>} data - Form data
+   * @param  {Strapi5RequestParams} [params] - Query parameters
    * @returns Promise<T>
    */
-  const create = <T>(contentType: string, data: Partial<T>): Promise<Strapi5ResponseSingle<T>> => {
-    return client(`/${contentType}`, { method: 'POST', body: { data } })
+  const create = <T>(contentType: string, data: Partial<T>, params: Strapi5RequestParams = {}): Promise<Strapi5ResponseSingle<T>> => {
+    return client(`/${contentType}`, { method: 'POST', body: { data }, params })
   }
 
   /**
@@ -61,9 +62,10 @@ export const useStrapi = <T>(): StrapiV5Client<T> => {
    * @param  {string} contentType - Content type's name pluralized
    * @param  {string} documentId - ID of entry to be updated
    * @param  {Record<string, any>} data - Form data
+   * @param  {Strapi5RequestParams} [params] - Query parameters
    * @returns Promise<T>
    */
-  const update = <T>(contentType: string, documentId: string | Partial<T>, data?: Partial<T>): Promise<Strapi5ResponseSingle<T>> => {
+  const update = <T>(contentType: string, documentId: string | Partial<T>, data?: Partial<T>, params: Strapi5RequestParams = {}): Promise<Strapi5ResponseSingle<T>> => {
     if (typeof documentId === 'object') {
       data = documentId
       documentId = undefined


### PR DESCRIPTION
This change gives the developer the ability to send params while doing a create/update for Strapiv5.
The `Strapi5RequestParams` option was added to both functions.
I may be wrong about this so feel free to discard this PR if this is not a thing in v5(I am sure I read it somewhere)
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This change gives the developer the ability to send params while doing a create/update for Strapiv5.

I think Strapi allows you to do stuff like populate on create
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
