### PR TITLE
fix(v5): publicationState and its values have been renamed

### DIFF
--- a/src/runtime/types/v5.ts
+++ b/src/runtime/types/v5.ts
@@ -15,7 +15,7 @@ export interface Strapi5RequestParams {
   sort?: string | Array<string>
   pagination?: PaginationByOffset | PaginationByPage
   filters?: Record<string, unknown>
-  publicationState?: 'live' | 'preview'
+  status?: 'published' | 'draft'
   locale?: StrapiLocale | null
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
The `publicationState` has been renamed to `status` in v5 and its values are not the same.
https://docs.strapi.io/dev-docs/api/rest/filters-locale-publication#status


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
