### PR TITLE
types(v4/v5): upgrade populate request param to include nested object

### DIFF
--- a/src/runtime/types/v4.ts
+++ b/src/runtime/types/v4.ts
@@ -31,10 +31,10 @@ export interface Strapi4RequestParams<T> {
   locale?: StrapiLocale
 }
 
-type Strapi4RequestPopulateParams<T> = Pick<Strapi4RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
+export type Strapi4RequestPopulateParams<T> = Pick<Strapi4RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
 
 // Unified type for Strapi populate, combining both string paths and nested objects.
-type Strapi4RequestPopulateParam<T> =
+export type Strapi4RequestPopulateParam<T> =
   | '*' // Populate all relations.
   | { [K in keyof T]?: // Nested object population.
     T[K] extends object

--- a/src/runtime/types/v4.ts
+++ b/src/runtime/types/v4.ts
@@ -31,7 +31,7 @@ export interface Strapi4RequestParams<T> {
   locale?: StrapiLocale
 }
 
-type StrapiV5RequestPopulateParams<T> = Pick<Strapi4RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
+type Strapi4RequestPopulateParams<T> = Pick<Strapi4RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
 
 // Unified type for Strapi populate, combining both string paths and nested objects.
 type Strapi4RequestPopulateParam<T> =
@@ -39,8 +39,8 @@ type Strapi4RequestPopulateParam<T> =
   | { [K in keyof T]?: // Nested object population.
     T[K] extends object
       ? T[K] extends Array<infer I>
-        ? Strapi4RequestPopulateParam<I> | StrapiV5RequestPopulateParams<I>
-        : Strapi4RequestPopulateParam<T[K]> | StrapiV5RequestPopulateParams<T[K]>
+        ? Strapi4RequestPopulateParam<I> | Strapi4RequestPopulateParams<I>
+        : Strapi4RequestPopulateParam<T[K]> | Strapi4RequestPopulateParams<T[K]>
       : never
   }
   | StrapiRequestParamPopulate<T> // String paths like "field.subfield".

--- a/src/runtime/types/v4.ts
+++ b/src/runtime/types/v4.ts
@@ -23,13 +23,28 @@ export interface PaginationByOffset {
 
 export interface Strapi4RequestParams<T> {
   fields?: Array<StrapiRequestParamField<T>>
-  populate?: '*' | StrapiRequestParamPopulate<T> | Array<StrapiRequestParamPopulate<T>>
+  populate?: Strapi4RequestPopulateParam<T>
   sort?: StrapiRequestParamSort<T> | Array<StrapiRequestParamSort<T>>
   pagination?: PaginationByOffset | PaginationByPage
   filters?: Record<string, unknown>
   publicationState?: 'live' | 'preview'
   locale?: StrapiLocale
 }
+
+type StrapiV5RequestPopulateParams<T> = Pick<Strapi4RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
+
+// Unified type for Strapi populate, combining both string paths and nested objects.
+type Strapi4RequestPopulateParam<T> =
+  | '*' // Populate all relations.
+  | { [K in keyof T]?: // Nested object population.
+    T[K] extends object
+      ? T[K] extends Array<infer I>
+        ? Strapi4RequestPopulateParam<I> | StrapiV5RequestPopulateParams<I>
+        : Strapi4RequestPopulateParam<T[K]> | StrapiV5RequestPopulateParams<T[K]>
+      : never
+  }
+  | StrapiRequestParamPopulate<T> // String paths like "field.subfield".
+  | Array<StrapiRequestParamPopulate<T>> // Array of string paths.
 
 export interface Strapi4ResponseData<T> {
   id: number

--- a/src/runtime/types/v5.ts
+++ b/src/runtime/types/v5.ts
@@ -11,7 +11,7 @@ export interface Strapi5Error {
 
 export interface Strapi5RequestParams<T> {
   fields?: Array<StrapiRequestParamField<T>>
-  populate?: StrapiV5RequestPopulateParam<T>
+  populate?: Strapi5RequestPopulateParam<T>
   sort?: StrapiRequestParamSort<T> | Array<StrapiRequestParamSort<T>>
   pagination?: PaginationByOffset | PaginationByPage
   filters?: Record<string, unknown>
@@ -19,16 +19,16 @@ export interface Strapi5RequestParams<T> {
   locale?: StrapiLocale | null
 }
 
-type StrapiV5RequestPopulateParams<T> = Pick<Strapi5RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
+type Strapi5RequestPopulateParams<T> = Pick<Strapi5RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
 
 // Unified type for Strapi populate, combining both string paths and nested objects.
-type StrapiV5RequestPopulateParam<T> =
+type Strapi5RequestPopulateParam<T> =
   | '*' // Populate all relations.
   | { [K in keyof T]?: // Nested object population.
     T[K] extends object
       ? T[K] extends Array<infer I>
-        ? StrapiV5RequestPopulateParam<I> | StrapiV5RequestPopulateParams<I>
-        : StrapiV5RequestPopulateParam<T[K]> | StrapiV5RequestPopulateParams<T[K]>
+        ? Strapi5RequestPopulateParam<I> | Strapi5RequestPopulateParams<I>
+        : Strapi5RequestPopulateParam<T[K]> | Strapi5RequestPopulateParams<T[K]>
       : never
   }
   | StrapiRequestParamPopulate<T> // String paths like "field.subfield".

--- a/src/runtime/types/v5.ts
+++ b/src/runtime/types/v5.ts
@@ -11,13 +11,28 @@ export interface Strapi5Error {
 
 export interface Strapi5RequestParams<T> {
   fields?: Array<StrapiRequestParamField<T>>
-  populate?: '*' | StrapiRequestParamPopulate<T> | Array<StrapiRequestParamPopulate<T>>
+  populate?: StrapiV5RequestPopulateParam<T>
   sort?: StrapiRequestParamSort<T> | Array<StrapiRequestParamSort<T>>
   pagination?: PaginationByOffset | PaginationByPage
   filters?: Record<string, unknown>
   status?: 'published' | 'draft'
   locale?: StrapiLocale | null
 }
+
+type StrapiV5RequestPopulateParams<T> = Pick<Strapi5RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
+
+// Unified type for Strapi populate, combining both string paths and nested objects.
+type StrapiV5RequestPopulateParam<T> =
+  | '*' // Populate all relations.
+  | { [K in keyof T]?: // Nested object population.
+    T[K] extends object
+      ? T[K] extends Array<infer I>
+        ? StrapiV5RequestPopulateParam<I> | StrapiV5RequestPopulateParams<I>
+        : StrapiV5RequestPopulateParam<T[K]> | StrapiV5RequestPopulateParams<T[K]>
+      : never
+  }
+  | StrapiRequestParamPopulate<T> // String paths like "field.subfield".
+  | Array<StrapiRequestParamPopulate<T>> // Array of string paths.
 
 export interface StrapiSystemFields {
   documentId: string

--- a/src/runtime/types/v5.ts
+++ b/src/runtime/types/v5.ts
@@ -19,10 +19,10 @@ export interface Strapi5RequestParams<T> {
   locale?: StrapiLocale | null
 }
 
-type Strapi5RequestPopulateParams<T> = Pick<Strapi5RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
+export type Strapi5RequestPopulateParams<T> = Pick<Strapi5RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
 
 // Unified type for Strapi populate, combining both string paths and nested objects.
-type Strapi5RequestPopulateParam<T> =
+export type Strapi5RequestPopulateParam<T> =
   | '*' // Populate all relations.
   | { [K in keyof T]?: // Nested object population.
     T[K] extends object


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## Description

### Changes:
Added new unified types for `populate` parameters in Strapi v5 and v4 to support nested object population and advanced filtering, sorting, and field selections. These types improve maintainability and consistency across versions.

#### Strapi v5:
- **New `StrapiV5RequestPopulateParams`**:  
  A type alias for `Pick<Strapi5RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>` to define allowed keys for nested population parameters.

- **New `StrapiV5RequestPopulateParam`**:  
  Unified type for `populate`, supporting:  
  - `'*'` for populating all relations.  
  - Nested objects for advanced population with `StrapiV5RequestPopulateParams` support.  
  - String paths like `"field.subfield"` or arrays of such paths.

#### Strapi v4:
- **New `Strapi4RequestPopulateParams`**:  
  Similar to v5, but tailored for `Strapi4RequestParams<T>`.

- **New `Strapi4RequestPopulateParam`**:  
  Similar functionality as the v5 version but applied to Strapi v4.

### Why this change is needed:
- Enhances type safety for `populate` usage across Strapi v4 and v5 implementations.
- Improves developer experience by standardizing the structure of nested population parameters.
- Simplifies handling of `fields`, `sort`, and `filters` in nested relations.

I tested it a bit in TS Playground and does seem to work as intended.

---

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (not applicable as this is a types-only update).
