### PR TITLE
types(v4/v5): filter request parameter types

### DIFF
--- a/src/runtime/composables-v5/useStrapi.ts
+++ b/src/runtime/composables-v5/useStrapi.ts
@@ -29,15 +29,10 @@ export const useStrapi = <T>(): StrapiV5Client<T> => {
    *
    * @param  {string} contentType - Content type's name pluralized
    * @param  {string} documentId - ID of entry
-   * @param  {Strapi5RequestParams<T>} [params] - Query parameters
+   * @param  {Omit<Strapi5RequestParams<T>, 'filter'>} [params] - Query parameters
    * @returns Promise<T>
    */
-  const findOne = <T>(contentType: string, documentId?: string | Strapi5RequestParams<T>, params?: Strapi5RequestParams<T>, fetchOptions?: FetchOptions): Promise<Strapi5ResponseSingle<T>> => {
-    if (typeof documentId === 'object') {
-      params = documentId
-      documentId = undefined
-    }
-
+  const findOne = <T>(contentType: string, documentId: string, params?: Omit<Strapi5RequestParams<T>, 'filter'>, fetchOptions?: FetchOptions): Promise<Strapi5ResponseSingle<T>> => {
     const path = [contentType, documentId].filter(Boolean).join('/')
 
     return client(path, { method: 'GET', params, ...fetchOptions })
@@ -48,10 +43,10 @@ export const useStrapi = <T>(): StrapiV5Client<T> => {
    *
    * @param  {string} contentType - Content type's name pluralized
    * @param  {Record<string, any>} data - Form data
-   * @param  {Strapi5RequestParams<T>} [params] - Query parameters
+   * @param  {Omit<Strapi5RequestParams<T>, 'filter'>} [params] - Query parameters
    * @returns Promise<T>
    */
-  const create = <T>(contentType: string, data: Partial<T>, params: Strapi5RequestParams<T> = {}): Promise<Strapi5ResponseSingle<T>> => {
+  const create = <T>(contentType: string, data: Partial<T>, params: Omit<Strapi5RequestParams<T>, 'filter'> = {}): Promise<Strapi5ResponseSingle<T>> => {
     return client(`/${contentType}`, { method: 'POST', body: { data }, params })
   }
 
@@ -61,10 +56,10 @@ export const useStrapi = <T>(): StrapiV5Client<T> => {
    * @param  {string} contentType - Content type's name pluralized
    * @param  {string} documentId - ID of entry to be updated
    * @param  {Record<string, any>} data - Form data
-   * @param  {Strapi5RequestParams<T>} [params] - Query parameters
+   * @param  {Omit<Strapi5RequestParams<T>, 'filter'>} [params] - Query parameters
    * @returns Promise<T>
    */
-  const update = <T>(contentType: string, documentId: string | Partial<T>, data?: Partial<T>, params: Strapi5RequestParams<T> = {}): Promise<Strapi5ResponseSingle<T>> => {
+  const update = <T>(contentType: string, documentId: string | Partial<T>, data?: Partial<T>, params: Omit<Strapi5RequestParams<T>, 'filter'> = {}): Promise<Strapi5ResponseSingle<T>> => {
     if (typeof documentId === 'object') {
       data = documentId
       documentId = undefined

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -586,6 +586,45 @@ export type StrapiRequestParamPopulate<T> = {
     : never;
 }[keyof T]
 
+// General operator type for primitive values (string, number, boolean)
+export type StrapiPrimitiveOperators<T> =
+  | { $eq: T } // Equal to a value
+  | { $ne: T } // Not equal to a value
+  | { $in: T[] } // Included in an array of values
+  | { $notIn: T[] } // Not included in an array of values
+  | { $null: boolean } // Is null
+  | { $notNull: boolean } // Is not null
+  | { $or: StrapiFilterRequestParam<T>[] } // "Or" condition
+  | { $and: StrapiFilterRequestParam<T>[] } // "And" condition
+  | { $not: StrapiFilterRequestParam<T> } // "Not" condition
+
+// String-specific operators
+export type StrapiStringOperators =
+  | { $eqi: string } // Equal (case-insensitive)
+  | { $contains: string } // Contains a substring
+  | { $notContains: string } // Does not contain a substring
+  | { $containsi: string } // Contains a substring (case-insensitive)
+  | { $notContainsi: string } // Does not contain a substring (case-insensitive)
+  | { $startsWith: string } // Starts with a substring
+  | { $startsWithi: string } // Starts with a substring (case-insensitive)
+  | { $endsWith: string } // Ends with a substring
+  | { $endsWithi: string } // Ends with a substring (case-insensitive)
+
+// Numeric-specific operators
+export type StrapiNumberOperators =
+  | { $lt: number } // Less than a value
+  | { $lte: number } // Less than or equal to a value
+  | { $gt: number } // Greater than a value
+  | { $gte: number } // Greater than or equal to a value
+  | { $between: [number, number] } // Is between two values
+
+// Base type for filters
+export type StrapiFilterRequestParam<T> = T extends object
+  ? {
+      [K in keyof T]?: StrapiFilterRequestParam<T[K]>; // Nested filtering for objects
+    }
+  : StrapiPrimitiveOperators<T> | (T extends string ? StrapiStringOperators : T extends number ? StrapiNumberOperators : never) // Apply operators based on field type
+
 export * from './v3'
 export * from './v4'
 export * from './v5'

--- a/src/runtime/types/v4.ts
+++ b/src/runtime/types/v4.ts
@@ -1,4 +1,4 @@
-import type { StrapiLocale, StrapiRequestParamField, StrapiRequestParamPopulate, StrapiRequestParamSort } from '.'
+import type { StrapiFilterRequestParam, StrapiLocale, StrapiRequestParamField, StrapiRequestParamPopulate, StrapiRequestParamSort } from '.'
 
 export interface Strapi4Error {
   error: {
@@ -26,7 +26,7 @@ export interface Strapi4RequestParams<T> {
   populate?: Strapi4RequestPopulateParam<T>
   sort?: StrapiRequestParamSort<T> | Array<StrapiRequestParamSort<T>>
   pagination?: PaginationByOffset | PaginationByPage
-  filters?: Record<string, unknown>
+  filters?: StrapiFilterRequestParam<T>
   publicationState?: 'live' | 'preview'
   locale?: StrapiLocale
 }

--- a/src/runtime/types/v4.ts
+++ b/src/runtime/types/v4.ts
@@ -31,7 +31,7 @@ export interface Strapi4RequestParams<T> {
   locale?: StrapiLocale
 }
 
-type StrapiV5RequestPopulateParams<T> = Pick<Strapi4RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
+type Strapi4RequestPopulateParams<T> = Pick<Strapi4RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
 
 // Unified type for Strapi populate, combining both string paths and nested objects.
 type Strapi4RequestPopulateParam<T> =
@@ -39,8 +39,8 @@ type Strapi4RequestPopulateParam<T> =
   | { [K in keyof T]?: // Nested object population.
     T[K] extends object
       ? T[K] extends Array<infer I>
-        ? Strapi4RequestPopulateParam<I> | StrapiV5RequestPopulateParams<I>
-        : Strapi4RequestPopulateParam<T[K]> | StrapiV5RequestPopulateParams<T[K]>
+        ? Strapi4RequestPopulateParam<I> | Strapi4RequestPopulateParams<I>
+        : Strapi4RequestPopulateParam<T[K]> | Strapi4RequestPopulateParams<T[K]>
       : never
   }
   | StrapiRequestParamPopulate<T> // String paths like "field.subfield".

--- a/src/runtime/types/v4.ts
+++ b/src/runtime/types/v4.ts
@@ -23,13 +23,28 @@ export interface PaginationByOffset {
 
 export interface Strapi4RequestParams<T> {
   fields?: Array<StrapiRequestParamField<T>>
-  populate?: '*' | StrapiRequestParamPopulate<T> | Array<StrapiRequestParamPopulate<T>>
+  populate?: Strapi4RequestPopulateParam<T>
   sort?: StrapiRequestParamSort<T> | Array<StrapiRequestParamSort<T>>
   pagination?: PaginationByOffset | PaginationByPage
   filters?: Record<string, unknown>
   publicationState?: 'live' | 'preview'
   locale?: StrapiLocale
 }
+
+type StrapiV5RequestPopulateParams<T> = Pick<Strapi4RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
+
+// Unified type for Strapi populate, combining both string paths and nested objects.
+type Strapi4RequestPopulateParam<T> =
+  | '*' // Populate all relations.
+  | { [K in keyof T]?: // Nested object population.
+    T[K] extends object
+      ? T[K] extends Array<infer I>
+        ? Strapi4RequestPopulateParam<I> | StrapiV5RequestPopulateParams<I>
+        : Strapi4RequestPopulateParam<T[K]> | StrapiV5RequestPopulateParams<T[K]>
+      : never
+  }
+  | StrapiRequestParamPopulate<T> // String paths like "field.subfield".
+  | Array<StrapiRequestParamPopulate<T>> // Array of string paths.
 
 export interface Strapi4ResponseData<T> {
   id: number

--- a/src/runtime/types/v5.ts
+++ b/src/runtime/types/v5.ts
@@ -11,7 +11,7 @@ export interface Strapi5Error {
 
 export interface Strapi5RequestParams<T> {
   fields?: Array<StrapiRequestParamField<T>>
-  populate?: StrapiV5RequestPopulateParam<T>
+  populate?: Strapi5RequestPopulateParam<T>
   sort?: StrapiRequestParamSort<T> | Array<StrapiRequestParamSort<T>>
   pagination?: PaginationByOffset | PaginationByPage
   filters?: Record<string, unknown>
@@ -19,16 +19,16 @@ export interface Strapi5RequestParams<T> {
   locale?: StrapiLocale | null
 }
 
-type StrapiV5RequestPopulateParams<T> = Pick<Strapi5RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
+type Strapi5RequestPopulateParams<T> = Pick<Strapi5RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
 
 // Unified type for Strapi populate, combining both string paths and nested objects.
-type StrapiV5RequestPopulateParam<T> =
+type Strapi5RequestPopulateParam<T> =
   | '*' // Populate all relations.
   | { [K in keyof T]?: // Nested object population.
     T[K] extends object
       ? T[K] extends Array<infer I>
-        ? StrapiV5RequestPopulateParam<I> | StrapiV5RequestPopulateParams<I>
-        : StrapiV5RequestPopulateParam<T[K]> | StrapiV5RequestPopulateParams<T[K]>
+        ? Strapi5RequestPopulateParam<I> | Strapi5RequestPopulateParams<I>
+        : Strapi5RequestPopulateParam<T[K]> | Strapi5RequestPopulateParams<T[K]>
       : never
   }
   | StrapiRequestParamPopulate<T> // String paths like "field.subfield".

--- a/src/runtime/types/v5.ts
+++ b/src/runtime/types/v5.ts
@@ -11,13 +11,28 @@ export interface Strapi5Error {
 
 export interface Strapi5RequestParams<T> {
   fields?: Array<StrapiRequestParamField<T>>
-  populate?: '*' | StrapiRequestParamPopulate<T> | Array<StrapiRequestParamPopulate<T>>
+  populate?: StrapiV5RequestPopulateParam<T>
   sort?: StrapiRequestParamSort<T> | Array<StrapiRequestParamSort<T>>
   pagination?: PaginationByOffset | PaginationByPage
   filters?: Record<string, unknown>
   status?: 'published' | 'draft'
   locale?: StrapiLocale | null
 }
+
+type StrapiV5RequestPopulateParams<T> = Pick<Strapi5RequestParams<T>, 'fields' | 'sort' | 'populate' | 'filters'>
+
+// Unified type for Strapi populate, combining both string paths and nested objects.
+type StrapiV5RequestPopulateParam<T> =
+  | '*' // Populate all relations.
+  | { [K in keyof T]?: // Nested object population.
+    T[K] extends object
+      ? T[K] extends Array<infer I>
+        ? StrapiV5RequestPopulateParam<I> | StrapiV5RequestPopulateParams<I>
+        : StrapiV5RequestPopulateParam<T[K]> | StrapiV5RequestPopulateParams<T[K]>
+      : never
+  }
+  | StrapiRequestParamPopulate<T> // String paths like "field.subfield".
+  | Array<StrapiRequestParamPopulate<T>> // Array of string paths.
 
 export interface StrapiSystemFields {
   documentId: string

--- a/src/runtime/types/v5.ts
+++ b/src/runtime/types/v5.ts
@@ -1,4 +1,4 @@
-import type { MetaResponsePaginationByOffset, MetaResponsePaginationByPage, PaginationByOffset, PaginationByPage, StrapiLocale, StrapiRequestParamField, StrapiRequestParamPopulate, StrapiRequestParamSort } from '.'
+import type { MetaResponsePaginationByOffset, MetaResponsePaginationByPage, PaginationByOffset, PaginationByPage, StrapiLocale, StrapiRequestParamField, StrapiRequestParamPopulate, StrapiRequestParamSort, StrapiFilterRequestParam } from '.'
 
 export interface Strapi5Error {
   error: {
@@ -14,7 +14,7 @@ export interface Strapi5RequestParams<T> {
   populate?: Strapi5RequestPopulateParam<T>
   sort?: StrapiRequestParamSort<T> | Array<StrapiRequestParamSort<T>>
   pagination?: PaginationByOffset | PaginationByPage
-  filters?: Record<string, unknown>
+  filters?: StrapiFilterRequestParam<T>
   status?: 'published' | 'draft'
   locale?: StrapiLocale | null
 }


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
This PR introduces:
1. **Conditional typing for `StrapiRequestParams`**:
   - Ensures the `filters` field is included only for the `find` HTTP method.
   - Excludes `filters` for other HTTP methods like `findOne`, `create`, `update` and `delete`, improving type safety and enforcing correct parameter usage.

2. **New types for the `filters` parameter**:
   - Introduced a comprehensive type system for the `filters` parameter.
   - Filters allow defining conditions with supported operators (`$eq`, `$lt`, `$gt`, `$contains`, etc.) for querying fields in `findMany` requests.
   - Operators are context-sensitive, meaning only valid operators for a field's type (e.g., `string`, `number`, `boolean`) are allowed.
   - Prevents usage of operators on nested objects to enforce consistent API behavior.
   - Ensures only one operator can be used at a time for a given filter condition.

### Key Improvements:
- Strongly-typed filter conditions based on field types.
- Validation of operator applicability to ensure correct usage.
- Cleaner, more maintainable request parameters with utility types like `Omit` for conditional inclusion of fields.

### Example Usage:

#### `find` with Filters:
```typescript
const params: Strapi5RequestParams<{age: number, name: string}> = {
  fields: ['name', 'age'],
  sort: ['name'],
  filters: {
    age: { $gte: 18 },
    name: { $startsWith: 'John' },
  },
};
```
## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)