### PR TITLE
feat(module): add `token` option to be used as fallback

### DIFF
--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -30,6 +30,7 @@ Defaults:
 ```ts
 {
   url: process.env.STRAPI_URL || 'http://localhost:1337',
+  token: process.env.STRAPI_TOKEN || undefined
   prefix: '/api',
   admin: '/admin',
   version: 'v5',

--- a/docs/content/4.auth.md
+++ b/docs/content/4.auth.md
@@ -36,7 +36,7 @@ const user = useStrapiUser()
 
 ## `useStrapiToken`
 
-This composable is an helper to get the jwt token. It is used internally to get the `strapi_jwt` cookie.
+This composable is an helper to get the jwt token. It is used internally to get the `strapi_jwt` cookie. If the latter does not exist, this uses the config variable `token`
 
 ```ts
 const token = useStrapiToken()

--- a/src/module.ts
+++ b/src/module.ts
@@ -20,7 +20,7 @@ export interface ModuleOptions {
   url?: string
   /**
    * Strapi API TOKEN
-   * @default process.env.STRAPI_TOKEN'
+   * @default process.env.STRAPI_TOKEN
    * @type string
    */
   token?: string

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,6 +18,12 @@ export interface ModuleOptions {
    * @type string
    */
   url?: string
+  /**
+   * Strapi API TOKEN
+   * @default process.env.STRAPI_TOKEN'
+   * @type string
+   */
+  token?: string
 
   /**
    * Strapi Prefix
@@ -84,6 +90,7 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {
     url: process.env.STRAPI_URL || 'http://localhost:1337',
+    token: process.env.STRAPI_TOKEN,
     prefix: '/api',
     admin: '/admin',
     version: 'v5',

--- a/src/runtime/composables/useStrapiToken.ts
+++ b/src/runtime/composables/useStrapiToken.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'vue'
+import { ref, type Ref } from 'vue'
 import { useCookie, useNuxtApp, useRuntimeConfig } from '#imports'
 
 export const useStrapiToken = (): Ref<string | null> => {
@@ -14,7 +14,7 @@ export const useStrapiToken = (): Ref<string | null> => {
   nuxt._cookies[config.strapi.cookieName] = cookie
 
   if (!cookie.value && config.strapi.token) {
-    return config.strapi
+    return ref(config.strapi.token)
   }
 
   return cookie

--- a/src/runtime/composables/useStrapiToken.ts
+++ b/src/runtime/composables/useStrapiToken.ts
@@ -12,5 +12,10 @@ export const useStrapiToken = (): Ref<string | null> => {
 
   const cookie = useCookie<string | null>(config.strapi.cookieName, config.strapi.cookie)
   nuxt._cookies[config.strapi.cookieName] = cookie
+
+  if (!cookie.value && config.strapi.token) {
+    return config.strapi
+  }
+
   return cookie
 }


### PR DESCRIPTION
This feature allows to define in the configuration (nuxt.config.ts) a default token in the same way as the url. When this token is defined, and the value of the authentication cookie is falsy then this token is used for authentication to strapi

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
