### PR TITLE
fix(useStrapiToken): improve `nuxt._cookies` usage

### DIFF
--- a/src/runtime/composables/useStrapiToken.ts
+++ b/src/runtime/composables/useStrapiToken.ts
@@ -11,7 +11,7 @@ export const useStrapiToken = (): Ref<string | null> => {
   }
 
   const cookie = useCookie<string | null>(config.strapi.cookieName, config.strapi.cookie)
-  nuxt._cookies[config.strapi.cookieName] = cookie
+  nuxt._cookies[config.strapi.cookieName] = cookie.value
 
   if (!cookie.value && config.strapi.token) {
     return ref(config.strapi.token)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
It seems this has been a hidden bug for a few years?
`nuxt._cookies` is a `Record<string, unknown>` that holds the values of the cookies and not a ref?

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
