### PR TITLE
Fix/strapi media url

### DIFF
--- a/src/runtime/composables/useStrapiMedia.ts
+++ b/src/runtime/composables/useStrapiMedia.ts
@@ -1,7 +1,34 @@
 import { joinURL } from 'ufo'
 import { useRuntimeConfig } from '#imports'
 
-export const useStrapiMedia = (path: string): string => {
+/**
+ * Safely handles Strapi media URLs for both development and production environments.
+ *
+ * In development or self hosted, Strapi typically returns relative paths (e.g., '/uploads/image.jpg')
+ * In production (Strapi Cloud), Strapi returns full URLs (e.g., 'https://domain.media.strapiapp.com/image.jpg')
+ *
+ * This composable automatically detects the URL type and handles it appropriately:
+ * - Full URLs are returned as-is
+ * - Relative paths are processed
+ *
+ * @param path - The media URL from Strapi (can be relative or absolute)
+ * @returns The complete, accessible media URL
+ *
+ * @example
+ * // Development: '/uploads/favicon.svg' → 'http://localhost:1337/uploads/favicon.svg'
+ * // Production: 'https://domain.media.strapiapp.com/favicon.svg' → 'https://domain.media.strapiapp.com/favicon.svg'
+ */
+export const useStrapiMedia = (path?: string | null): string | undefined => {
+  if (!path || typeof path !== 'string' || path.trim() === '') return undefined
+
+  try {
+    // If path is already an absolute URL, return as-is
+    const url = new URL(path)
+    return url.href
+  } catch (_e) { // eslint-disable-line @typescript-eslint/no-unused-vars
+    // Not a valid absolute URL, treat as relative
+  }
+
   const config = import.meta.server ? useRuntimeConfig() : useRuntimeConfig().public
 
   return joinURL(config.strapi.url, path)

--- a/src/runtime/composables/useStrapiMedia.ts
+++ b/src/runtime/composables/useStrapiMedia.ts
@@ -18,11 +18,8 @@ import { useRuntimeConfig } from '#imports'
  * // Development: '/uploads/favicon.svg' → 'http://localhost:1337/uploads/favicon.svg'
  * // Production: 'https://domain.media.strapiapp.com/favicon.svg' → 'https://domain.media.strapiapp.com/favicon.svg'
  */
-export const useStrapiMedia = (path?: string | null): string | undefined => {
-  if (!path || typeof path !== 'string' || path.trim() === '') return undefined
-
+export const useStrapiMedia = (path: string): string => {
   try {
-    // If path is already an absolute URL, return as-is
     const url = new URL(path)
     return url.href
   } catch (_e) { // eslint-disable-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
- Add URL detection using new URL() constructor
- Return absolute URLs as-is without prepending base URL
- Maintain backward compatibility for relative paths
- Add documentation with examples

Fixes URL malformation in production environments where Strapi Cloud returns full URLs (e.g., https://domain.media.strapiapp.com/image.jpg) instead of relative paths, preventing double-prefixing with base URL.

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
On self hosted/local dev environments Strapi returns relative paths for media resources, Strapi Cloud hovewer returns an absolute path, thus the url useStrapiMedia would return will be something like https://{strapiURL}/https://{domain}.media.strapiapp.com/path

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
