### PR TITLE
fix(v5): missing Strapi5Error in useStrapiClient

### DIFF
--- a/src/runtime/composables/useStrapiClient.ts
+++ b/src/runtime/composables/useStrapiClient.ts
@@ -1,13 +1,22 @@
 import type { FetchError, FetchOptions } from 'ofetch'
 import { stringify } from 'qs'
-import type { Strapi4Error } from '../types/v4'
 import type { Strapi3Error } from '../types/v3'
+import type { Strapi4Error } from '../types/v4'
+import type { Strapi5Error } from '../types/v5'
 import { useStrapiUrl } from './useStrapiUrl'
 import { useStrapiVersion } from './useStrapiVersion'
 import { useStrapiToken } from './useStrapiToken'
 import { useNuxtApp } from '#imports'
 
 const defaultErrors = (err: FetchError) => ({
+  v5: {
+    error: {
+      status: 500,
+      name: 'UnknownError',
+      message: err.message,
+      details: err
+    }
+  },
   v4: {
     error: {
       status: 500,
@@ -57,7 +66,7 @@ export const useStrapiClient = () => {
         }
       })
     } catch (err) {
-      const e: Strapi4Error | Strapi3Error = err.data || defaultErrors(err)[version]
+      const e: Strapi3Error | Strapi4Error | Strapi5Error = err.data || defaultErrors(err)[version]
 
       nuxt.hooks.callHook('strapi:error', e)
       throw e
@@ -67,6 +76,6 @@ export const useStrapiClient = () => {
 
 declare module '#app' {
   interface RuntimeNuxtHooks {
-    'strapi:error': (error: Strapi3Error | Strapi4Error) => void
+    'strapi:error': (error: Strapi3Error | Strapi4Error | Strapi5Error) => void
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
For version v5, the default error declaration is missing. In this case, err.data is returned as an error. If you use a client with useAsyncData and an exception occurs in fetch, a 500 error will be returned with the message: “Cannot read properties of undefined (reading 'message')”.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
