### PR TITLE
docs: use native sqlite connector

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -1,6 +1,11 @@
 export default defineNuxtConfig({
   extends: ['docus'],
   css: ['~/assets/css/main.css'],
+  content: {
+    experimental: {
+      sqliteConnector: 'native'
+    }
+  },
   site: {
     name: 'Nuxt Strapi',
     url: 'https://strapi.nuxtjs.org'

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -1,14 +1,14 @@
 export default defineNuxtConfig({
   extends: ['docus'],
   css: ['~/assets/css/main.css'],
+  site: {
+    name: 'Nuxt Strapi',
+    url: 'https://strapi.nuxtjs.org'
+  },
   content: {
     experimental: {
       sqliteConnector: 'native'
     }
-  },
-  site: {
-    name: 'Nuxt Strapi',
-    url: 'https://strapi.nuxtjs.org'
   },
   llms: {
     domain: 'https://strapi.nuxtjs.org',

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "docus": "^5.13.0",
-    "better-sqlite3": "^12.11.1",
     "nuxt": "^4.5.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
 
   docs:
     dependencies:
-      better-sqlite3:
-        specifier: ^12.11.1
-        version: 12.11.1
       docus:
         specifier: ^5.13.0
         version: 5.13.0(3e37440cffe7573990d0b4971ef5c582)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,10 +6,10 @@ packages:
 linkWorkspacePackages: true
 
 allowBuilds:
-  better-sqlite3: true
   sharp: true
   '@parcel/watcher': false
   '@tailwindcss/oxide': false
   esbuild: false
   unrs-resolver: false
   vue-demi: false
+  better-sqlite3: false


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Switches the docs to Nuxt Content's native `node:sqlite` connector so `better-sqlite3` no longer needs to be installed and compiled. It stays as a transitive dependency of `@nuxt/content` but its build script is disabled.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)

Not applicable, docs-only change, verified with a docs build.